### PR TITLE
Fix jq command not found in /usr/local/bin path.

### DIFF
--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 source "$(dirname "$0")/common.sh"
+PATH=/usr/local/bin:$PATH
 
 if [[ -z "${SONAR_TOKEN}" ]]; then
   echo "Set the SONAR_TOKEN env variable."


### PR DESCRIPTION
I installed the JQ command using Homebrew in MacOS Runner.

```
$ brew install jq
```

When I use `sonarqube-quality-gate-action` the following error is reported:

```
sonarqube-quality-gate-action/master/script/check-quality-gate.sh: line 26: jq: command not found
```

I want `sonarqube-quality-gate-action` to support the /usr/local/bin path.

Thank you so much

