### PR TITLE
Check for sonar host url

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
       timeout-minutes: 5
       env:
        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+       SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }} #OPTIONAL
 
 ```
 
@@ -69,6 +70,8 @@ Example usage:
 ### Environment variables
 
 - `SONAR_TOKEN` – **Required** this is the token used to authenticate access to SonarQube. You can read more about security tokens [here](https://docs.sonarqube.org/latest/user-guide/user-token/). You can set the `SONAR_TOKEN` environment variable in the "Secrets" settings page of your repository, or you can add them at the level of your GitHub organization (recommended).
+
+- `SONAR_HOST_URL` – **Optional** this tells the scanner where SonarQube is hosted, otherwise it will get the one from the scan report. You can set the `SONAR_HOST_URL` environment variable in the "Secrets" settings page of your repository, or you can add them at the level of your GitHub organization (recommended).
 
 ## Quality Gate check run
 

--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -14,8 +14,13 @@ if [[ ! -f "$metadataFile" ]]; then
    exit 1
 fi
 
-serverUrl="$(sed -n 's/serverUrl=\(.*\)/\1/p' "${metadataFile}")"
-ceTaskUrl="$(sed -n 's/ceTaskUrl=\(.*\)/\1/p' "${metadataFile}")"
+if [[ -z "${SONAR_HOST_URL}" ]]; then
+   serverUrl="${SONAR_HOST_URL}"
+   ceTaskUrl="${SONAR_HOST_URL} + $(sed -n 's/.*api//p' "${metadataFile}")"
+else
+   serverUrl="$(sed -n 's/serverUrl=\(.*\)/\1/p' "${metadataFile}")"
+   ceTaskUrl="$(sed -n 's/ceTaskUrl=\(.*\)/\1/p' "${metadataFile}")"
+fi
 
 if [ -z "${serverUrl}" ] || [ -z "${ceTaskUrl}" ]; then
   echo "Invalid report metadata file."

--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -14,9 +14,9 @@ if [[ ! -f "$metadataFile" ]]; then
    exit 1
 fi
 
-if [[ -z "${SONAR_HOST_URL}" ]]; then
+if [[ ! -z "${SONAR_HOST_URL}" ]]; then
    serverUrl="${SONAR_HOST_URL}"
-   ceTaskUrl="${SONAR_HOST_URL} + $(sed -n 's/.*api//p' "${metadataFile}")"
+   ceTaskUrl="${SONAR_HOST_URL}/api$(sed -n 's/^ceTaskUrl=.*api//p' "${metadataFile}")"
 else
    serverUrl="$(sed -n 's/serverUrl=\(.*\)/\1/p' "${metadataFile}")"
    ceTaskUrl="$(sed -n 's/ceTaskUrl=\(.*\)/\1/p' "${metadataFile}")"


### PR DESCRIPTION
Sonarqube scan action(https://github.com/SonarSource/sonarqube-scan-action) supports an environment variable for SONAR_HOST_URL, but sonarqube-quality-gate-action(https://github.com/SonarSource/sonarqube-quality-gate-action) does not, as it picks the one from "report-task.txt".

With a simple check we can verify if a SONAR_HOST_URL is configured and in case it exists use it for serverUrl and ceTaskUrl. If it isn't configured, we will keep serverUrl and ceTaskUrl the same way as before.
