### PR TITLE
Support for a `quality-gate-status` output variable (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,29 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        # Disabling shallow clone is recommended for improving relevancy of reporting
+        # Disabling shallow clone is recommended for improving relevancy of reporting.
         fetch-depth: 0
-      # Triggering SonarQube analysis as results of it are required by Quality Gate check
+
+    # Triggering SonarQube analysis as results of it are required by Quality Gate check.
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+    # Check the Quality Gate status.
     - name: SonarQube Quality Gate check
+      id: sonarqube-quality-gate-check
       uses: sonarsource/sonarqube-quality-gate-action@master
-      # Force to fail step after specific time
+      # Force to fail step after specific time.
       timeout-minutes: 5
       env:
        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    # Optionally you can use the output from the Quality Gate in another step.
+    # The possible outputs of the `quality-gate-status` variable are `PASSED`, `WARN` or `FAILED`.
+    - name: "Example show SonarQube Quality Gate Status value"
+      run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
 
 ```
 
@@ -54,11 +63,13 @@ Make sure to set up `timeout-minutes` property in your step, to avoid wasting ac
 When using this action with [sonarsource/sonarqube-scan](https://github.com/SonarSource/sonarqube-scan-action) action or with [C/C++ code analysis](https://docs.sonarqube.org/latest/analysis/languages/cfamily/) you don't have to provide `scanMetadataReportFile` input, otherwise you should alter the location of it.
 
 Typically, report metadata file for different scanners can vary and can be located in:
+
 - `target/sonar/report-task.txt` for Maven projects
 - `build/sonar/report-task.txt` for Gradle projects
 - `.sonarqube/out/.sonar/report-task.txt` for .NET projects
 
 Example usage:
+
 ```yaml
 - name: SonarQube Quality Gate check
   uses: sonarsource/sonarqube-quality-gate-action@master

--- a/action.yml
+++ b/action.yml
@@ -14,3 +14,7 @@ inputs:
     description: Location of the scanner metadata report file
     required: false
     default: .scannerwork/report-task.txt
+outputs:
+  quality-gate-status:
+    description: >
+      The resulting Quality Gate Status value of PASSED, WARN or FAILED

--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -37,12 +37,16 @@ qualityGateUrl="${serverUrl}/api/qualitygates/project_status?analysisId=${analys
 qualityGateStatus="$(curl --silent --fail --show-error --user "${SONAR_TOKEN}": "${qualityGateUrl}" | jq -r '.projectStatus.status')"
 
 if [[ ${qualityGateStatus} == "OK" ]];then
+   echo '::set-output name=quality-gate-status::PASSED'
    success "Quality Gate has PASSED."
 elif [[ ${qualityGateStatus} == "WARN" ]];then
+   echo '::set-output name=quality-gate-status::WARN'
    warn "Warnings on Quality Gate."
 elif [[ ${qualityGateStatus} == "ERROR" ]];then
+   echo '::set-output name=quality-gate-status::FAILED'
    fail "Quality Gate has FAILED."
 else
+   echo '::set-output name=quality-gate-status::FAILED'
    fail "Quality Gate not set for the project. Please configure the Quality Gate in SonarQube or remove sonarqube-quality-gate action from the workflow."
 fi
 

--- a/test/check-quality-gate-test.bats
+++ b/test/check-quality-gate-test.bats
@@ -45,6 +45,7 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 1 ]
   [[ "$output" = *"Quality Gate not set for the project. Please configure the Quality Gate in SonarQube or remove sonarqube-quality-gate action from the workflow."* ]]
+  [[ "$output" = *"name=quality-gate-status::FAILED"* ]]
 }
 
 @test "fail when Quality Gate status WARN" {
@@ -66,6 +67,7 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 1 ]
   [[ "$output" = *"Warnings on Quality Gate."* ]]
+  [[ "$output" = *"name=quality-gate-status::WARN"* ]]
 }
 
 @test "fail when Quality Gate status ERROR" {
@@ -87,6 +89,7 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 1 ]
   [[ "$output" = *"Quality Gate has FAILED."* ]]
+  [[ "$output" = *"name=quality-gate-status::FAILED"* ]]
 }
 
 @test "pass when Quality Gate status OK" {
@@ -108,5 +111,6 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 0 ]
   [[ "$output" = *"Quality Gate has PASSED."* ]]
+  [[ "$output" = *"name=quality-gate-status::PASSED"* ]]
 }
 


### PR DESCRIPTION
This is an internal PR for #14. It contains the original changes, plus the request updates (mainly wording + unit test).