### PR TITLE
expose the analysis ID as an output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ branding:
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/script/check-quality-gate.sh ${{ inputs.scanMetadataReportFile  }}
+    - id: quality-gate-check
+      run: $GITHUB_ACTION_PATH/script/check-quality-gate.sh ${{ inputs.scanMetadataReportFile  }}
       shell: bash
 inputs:
   scanMetadataReportFile:
@@ -15,6 +16,11 @@ inputs:
     required: false
     default: .scannerwork/report-task.txt
 outputs:
+  analysis-id:
+    description: >
+      The ID identifying the scan on the SonarQube backend
+    value: ${{ steps.quality-gate-check.outputs.analysis-id }}
   quality-gate-status:
     description: >
       The resulting Quality Gate Status value of PASSED, WARN or FAILED
+    value: ${{ steps.quality-gate-check.outputs.quality-gate-status }}

--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -41,6 +41,7 @@ analysisId="$(jq -r '.task.analysisId' <<< "${task}")"
 qualityGateUrl="${serverUrl}/api/qualitygates/project_status?analysisId=${analysisId}"
 qualityGateStatus="$(curl --silent --fail --show-error --user "${SONAR_TOKEN}": "${qualityGateUrl}" | jq -r '.projectStatus.status')"
 
+echo "::set-output name=analysis-id::${analysisId}"
 if [[ ${qualityGateStatus} == "OK" ]]; then
    echo '::set-output name=quality-gate-status::PASSED'
    success "Quality Gate has PASSED."

--- a/test/check-quality-gate-test.bats
+++ b/test/check-quality-gate-test.bats
@@ -68,6 +68,7 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 1 ]
   [[ "$output" = *"Quality Gate not set for the project. Please configure the Quality Gate in SonarQube or remove sonarqube-quality-gate action from the workflow."* ]]
+  [[ "$output" = *"name=analysis-id::AXlCe3jz9LkwR9Gs0pBY"* ]]
   [[ "$output" = *"name=quality-gate-status::FAILED"* ]]
 }
 
@@ -90,6 +91,7 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 1 ]
   [[ "$output" = *"Warnings on Quality Gate."* ]]
+  [[ "$output" = *"name=analysis-id::AXlCe3jz9LkwR9Gs0pBY"* ]]
   [[ "$output" = *"name=quality-gate-status::WARN"* ]]
 }
 
@@ -112,6 +114,7 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 1 ]
   [[ "$output" = *"Quality Gate has FAILED."* ]]
+  [[ "$output" = *"name=analysis-id::AXlCe3jz9LkwR9Gs0pBY"* ]]
   [[ "$output" = *"name=quality-gate-status::FAILED"* ]]
 }
 
@@ -134,6 +137,7 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp
   [ "$status" -eq 0 ]
   [[ "$output" = *"Quality Gate has PASSED."* ]]
+  [[ "$output" = *"name=analysis-id::AXlCe3jz9LkwR9Gs0pBY"* ]]
   [[ "$output" = *"name=quality-gate-status::PASSED"* ]]
 }
 


### PR DESCRIPTION
My organization requires us to download reports for the scan results and save them as artifacts as evidence they passed. From my understanding the best way to make sure we download the correct reports is with the analysis ID, and it would be much easier to get that if it was exposed by this action.