### PR TITLE
Ensure `::set-output` is clean

### DIFF
--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -41,6 +41,7 @@ analysisId="$(jq -r '.task.analysisId' <<< "${task}")"
 qualityGateUrl="${serverUrl}/api/qualitygates/project_status?analysisId=${analysisId}"
 qualityGateStatus="$(curl --location --location-trusted --max-redirs 10 --silent --fail --show-error --user "${SONAR_TOKEN}": "${qualityGateUrl}" | jq -r '.projectStatus.status')"
 
+printf '\n'
 if [[ ${qualityGateStatus} == "OK" ]]; then
    echo '::set-output name=quality-gate-status::PASSED'
    success "Quality Gate has PASSED."


### PR DESCRIPTION
If task status starts out in `PENDING` or `IN_PROGRESS` the dots generated in the status polling loop end up prepended to `::set-output` and break the action outputs.

This adds a newline after the loop to make sure that `::set-output` is clean.

Alternatively, printing the dots to STDERR might work just as well

Adds a test and fixes #21