### PR TITLE
[BUG] Amiguous redirect when GITHUB_OUTPUT is not set

### DIFF
--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -43,16 +43,16 @@ qualityGateStatus="$(curl --location --location-trusted --max-redirs 10 --silent
 
 printf '\n'
 if [[ ${qualityGateStatus} == "OK" ]]; then
-   echo 'quality-gate-status=PASSED' >> ${GITHUB_OUTPUT}
+   echo 'quality-gate-status=PASSED' >> "${GITHUB_OUTPUT}"
    success "Quality Gate has PASSED."
 elif [[ ${qualityGateStatus} == "WARN" ]]; then
-   echo 'quality-gate-status=WARN' >> ${GITHUB_OUTPUT}
+   echo 'quality-gate-status=WARN' >> "${GITHUB_OUTPUT}"
    warn "Warnings on Quality Gate."
 elif [[ ${qualityGateStatus} == "ERROR" ]]; then
-   echo 'quality-gate-status=FAILED' >> ${GITHUB_OUTPUT}
+   echo 'quality-gate-status=FAILED' >> "${GITHUB_OUTPUT}"
    fail "Quality Gate has FAILED."
 else
-   echo 'quality-gate-status=FAILED' >> ${GITHUB_OUTPUT}
+   echo 'quality-gate-status=FAILED' >> "${GITHUB_OUTPUT}"
    fail "Quality Gate not set for the project. Please configure the Quality Gate in SonarQube or remove sonarqube-quality-gate action from the workflow."
 fi
 

--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -43,16 +43,16 @@ qualityGateStatus="$(curl --location --location-trusted --max-redirs 10 --silent
 
 printf '\n'
 if [[ ${qualityGateStatus} == "OK" ]]; then
-   echo 'quality-gate-status=PASSED' >> "${GITHUB_OUTPUT}"
+   set_output "quality-gate-status" "PASSED"
    success "Quality Gate has PASSED."
 elif [[ ${qualityGateStatus} == "WARN" ]]; then
-   echo 'quality-gate-status=WARN' >> "${GITHUB_OUTPUT}"
+   set_output "quality-gate-status" "WARN"
    warn "Warnings on Quality Gate."
 elif [[ ${qualityGateStatus} == "ERROR" ]]; then
-   echo 'quality-gate-status=FAILED' >> "${GITHUB_OUTPUT}"
+   set_output "quality-gate-status" "FAILED"
    fail "Quality Gate has FAILED."
 else
-   echo 'quality-gate-status=FAILED' >> "${GITHUB_OUTPUT}"
+   set_output "quality-gate-status" "FAILED"
    fail "Quality Gate not set for the project. Please configure the Quality Gate in SonarQube or remove sonarqube-quality-gate action from the workflow."
 fi
 

--- a/script/common.sh
+++ b/script/common.sh
@@ -23,6 +23,15 @@ success() { echo -e "${green}✔ $*${reset}"; }
 warn() { echo -e "${yellow}✖ $*${reset}"; exit 1; }
 fail() { echo -e "${red}✖ $*${reset}"; exit 1; }
 
+# support old GH Actions runners
+set_output () {
+  if [[ -n "${GITHUB_OUTPUT}" ]]; then
+    echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
+  else
+    echo "::set-output name=${1}::${2}"
+  fi
+}
+
 ## Enable debug mode.
 enable_debug() {
   if [[ "${DEBUG}" == "true" ]]; then


### PR DESCRIPTION
Not everyone is on the latest Github Actions runners.  Fall back to `set-output` for workflows which have not migrated or are using custom/organizational runners. 

Fixes #32 
Fixes #31 