### PR TITLE
Include SONAR_ROOT_CERT option custom TRA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Example usage:
 
 - `SONAR_HOST_URL` – **Optional** this tells the scanner where SonarQube is hosted, otherwise it will get the one from the scan report. You can set the `SONAR_HOST_URL` environment variable in the "Secrets" settings page of your repository, or you can add them at the level of your GitHub organization (recommended).
 
+- `SONAR_ROOT_CERT` – Holds an additional root certificate (in PEM format) that is used to validate the SonarQube server certificate. You can set the `SONAR_ROOT_CERT` environment variable in the "Secrets" settings page of your repository, or you can add them at the level of your GitHub organization (recommended).
+
 ## Quality Gate check run
 
 <img src="./images/QualityGate-check-screen.png">

--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -27,6 +27,13 @@ if [ -z "${serverUrl}" ] || [ -z "${ceTaskUrl}" ]; then
   exit 1
 fi
 
+if [[ -n "${SONAR_ROOT_CERT}" ]]; then
+  echo "Adding custom root certificate to ~/.curlrc"
+  rm -f /tmp/tmpcert.pem
+  echo "${SONAR_ROOT_CERT}" > /tmp/tmpcert.pem
+  echo "--cacert /tmp/tmpcert.pem" >> ~/.curlrc
+fi
+
 task="$(curl --location --location-trusted --max-redirs 10  --silent --fail --show-error --user "${SONAR_TOKEN}": "${ceTaskUrl}")"
 status="$(jq -r '.task.status' <<< "$task")"
 


### PR DESCRIPTION
[sonarqube-scan-action](https://github.com/SonarSource/sonarqube-scan-action) supports the `SONAR_ROOT_CERT` option to allow for SonarQube installations with TLS certificates signed using custom Trusted Root Authority certificates.

Adding this option to [sonarqube-quality-gate-action](https://github.com/SonarSource/sonarqube-quality-gate-action) now permits this action to be used as a Quality Gate for private SonarQube installations.
