### PR TITLE
Change `sleep 5s` to `sleep 5` to support MacOS runners

### DIFF
--- a/script/check-quality-gate.sh
+++ b/script/check-quality-gate.sh
@@ -39,7 +39,7 @@ status="$(jq -r '.task.status' <<< "$task")"
 
 until [[ ${status} != "PENDING" && ${status} != "IN_PROGRESS" ]]; do
     printf '.'
-    sleep 5s
+    sleep 5
     task="$(curl --location --location-trusted --max-redirs 10 --silent --fail --show-error --user "${SONAR_TOKEN}": "${ceTaskUrl}")"
     status="$(jq -r '.task.status' <<< "$task")"
 done


### PR DESCRIPTION
See issue log [here](https://community.sonarsource.com/t/bug-fix-sonarqube-quality-gate-gh-action-bug-on-macos-runners/94832).

## Motives
My organization uses this GH Action to execute the quality gate on most of our systems. While most are Ubuntu / UNIX based systems, we also use MacOS for iOS / Swift builds. In configuring this, have noticed that the MacOS runners always fail when running `script/check-quality-gate.sh` in this GH Action. After investigating, we have noticed it is due to a benign command format that is not supported on MacOS. Additional information can be seen in the issue note above

## Fix
We have fixed line 42 to read `sleep 5` versus `sleep 5s`, which is not supported by MacOS. The new line is supported for both Ubuntu / UNIX-based systems as well as MacOS systems. 


Thanks!