### PR TITLE
Show the analysis results URL if the Quality Gate Status is `WARN` or `ERROR`

### DIFF
--- a/test/check-quality-gate-test.bats
+++ b/test/check-quality-gate-test.bats
@@ -81,6 +81,7 @@ teardown() {
   export SONAR_TOKEN="test"
   echo "serverUrl=http://localhost:9000" >> metadata_tmp
   echo "ceTaskUrl=http://localhost:9000/api/ce/task?id=AXlCe3gsFwOUsY8YKHTn" >> metadata_tmp
+  echo "dashboardUrl=http://localhost:9000/dashboard?id=project&branch=master" >> metadata_tmp
 
   #mock curl
   function curl() {
@@ -100,12 +101,14 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "${github_out_actual}" = "quality-gate-status=WARN" ]]
   [[ "$output" = *"Warnings on Quality Gate."* ]]
+  [[ "$output" = *"Detailed information can be found at: http://localhost:9000/dashboard?id=project&branch=master"* ]]
 }
 
 @test "fail when Quality Gate status ERROR" {
   export SONAR_TOKEN="test"
   echo "serverUrl=http://localhost:9000" >> metadata_tmp
   echo "ceTaskUrl=http://localhost:9000/api/ce/task?id=AXlCe3gsFwOUsY8YKHTn" >> metadata_tmp
+  echo "dashboardUrl=http://localhost:9000/dashboard?id=project&branch=master" >> metadata_tmp
 
   #mock curl
   function curl() {
@@ -125,6 +128,7 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "${github_out_actual}" = "quality-gate-status=FAILED" ]]
   [[ "$output" = *"Quality Gate has FAILED."* ]]
+  [[ "$output" = *"Detailed information can be found at: http://localhost:9000/dashboard?id=project&branch=master"* ]]
 }
 
 @test "pass when Quality Gate status OK" {
@@ -150,6 +154,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "${github_out_actual}" = "quality-gate-status=PASSED" ]]
   [[ "$output" = *"Quality Gate has PASSED."* ]]
+  [[ "$output" != *"Detailed information can be found at:"* ]]
 }
 
 @test "pass when Quality Gate status OK and status starts from IN_PROGRESS" {


### PR DESCRIPTION
- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Make sure any code you changed is covered by tests
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

# Abstract

This PR enables the display of the analysis URL if the Quality Gate Status is unsuccessful.

# Motivation

A common [usage](https://github.com/SonarSource/sonarqube-quality-gate-action#usage) of this action is to chain it with the [sonarsource/sonarqube-scan-action](https://github.com/SonarSource/sonarqube-scan-action) action. While the initial caller `sonarqube-scan-action` generates the URL for the dashboard in its log, the same does not apply to the `sonarqube-quality-gate-action`.

Particularly when encountering an `ERROR` or `WARN` status, signifying a failure during the execution of the `sonarqube-quality-gate-action` within the pipeline, there is an absence of explicit information elucidating the cause of the failure. To access this information, users are compelled to backtrack to the preceding step, where the successful execution of the `sonarqube-scan-action` occurred. This sequence of steps can be unintuitive and confusing, often leading to users seeking support to comprehend the reason behind the step's failure. This process requires multiple steps (such as navigating to the preceding step, expanding the step's output, and scrolling down to retrieve the URL) that could be avoided.

This pull request significantly enriches the developer experience by directly furnishing the URL at the point of failure, mitigating the need for these additional steps.