### PR TITLE
feat: add a polling timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: .scannerwork/report-task.txt
   pollingTimeoutSec:
-    description: "The maximal time (in seconds) to poll for SonarQube's Quality Gate. Default: 300."
+    description: "The maximum time (in seconds) to poll for SonarQube's Quality Gate status. Default: 300."
     required: false
     default: "300"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -8,13 +8,17 @@ runs:
   using: "composite"
   steps:
     - id: quality-gate-check
-      run: $GITHUB_ACTION_PATH/script/check-quality-gate.sh ${{ inputs.scanMetadataReportFile  }}
+      run: $GITHUB_ACTION_PATH/script/check-quality-gate.sh "${{ inputs.scanMetadataReportFile  }}" "${{ inputs.pollingTimeoutSec }}"
       shell: bash
 inputs:
   scanMetadataReportFile:
     description: Location of the scanner metadata report file
     required: false
     default: .scannerwork/report-task.txt
+  pollingTimeoutSec:
+    description: "The maximal time (in seconds) to poll for SonarQube's Quality Gate. Default: 300."
+    required: false
+    default: "300"
 outputs:
   quality-gate-status:
     description: >

--- a/test/check-quality-gate-test.bats
+++ b/test/check-quality-gate-test.bats
@@ -119,7 +119,6 @@ teardown() {
   run script/check-quality-gate.sh metadata_tmp 5
 
   [ "$status" -eq 1 ]
-  [[ "${github_out_actual}" = "quality-gate-status=FAILED" ]]
   [[ "$output" = *"Polling timeout reached for waiting for finishing of the Sonar scan! Aborting the check for SonarQube's Quality Gate."* ]]
 }
 

--- a/test/check-quality-gate-test.bats
+++ b/test/check-quality-gate-test.bats
@@ -38,7 +38,7 @@ teardown() {
   }
   export -f curl
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
   [ "$status" -eq 0 ]
 }
 
@@ -52,9 +52,37 @@ teardown() {
 
 @test "fail when empty metadata file" {
   export SONAR_TOKEN="test"
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
   [ "$status" -eq 1 ]
   [ "$output" = "Invalid report metadata file." ]
+}
+
+@test "fail when no polling timeout is provided" {
+  export SONAR_TOKEN="test"
+  run script/check-quality-gate.sh metadata_tmp
+  [ "$status" -eq 1 ]
+  [ "$output" = "'' is an invalid value for the polling timeout. Please use a positive, non-zero number." ]
+}
+
+@test "fail when polling timeout is not a number" {
+  export SONAR_TOKEN="test"
+  run script/check-quality-gate.sh metadata_tmp metadata_tmp
+  [ "$status" -eq 1 ]
+  [ "$output" = "'metadata_tmp' is an invalid value for the polling timeout. Please use a positive, non-zero number." ]
+}
+
+@test "fail when polling timeout is zero" {
+  export SONAR_TOKEN="test"
+  run script/check-quality-gate.sh metadata_tmp 0
+  [ "$status" -eq 1 ]
+  [ "$output" = "'0' is an invalid value for the polling timeout. Please use a positive, non-zero number." ]
+}
+
+@test "fail when polling timeout is negative" {
+  export SONAR_TOKEN="test"
+  run script/check-quality-gate.sh metadata_tmp -1
+  [ "$status" -eq 1 ]
+  [ "$output" = "'-1' is an invalid value for the polling timeout. Please use a positive, non-zero number." ]
 }
 
 @test "fail when no Quality Gate status" {
@@ -68,13 +96,31 @@ teardown() {
   }
   export -f curl
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
 
   read -r github_out_actual < ${GITHUB_OUTPUT}
 
   [ "$status" -eq 1 ]
   [[ "${github_out_actual}" = "quality-gate-status=FAILED" ]]
   [[ "$output" = *"Quality Gate not set for the project. Please configure the Quality Gate in SonarQube or remove sonarqube-quality-gate action from the workflow."* ]]
+}
+
+@test "fail when polling timeout is reached" {
+  export SONAR_TOKEN="test"
+  echo "serverUrl=http://localhost:9000" >> metadata_tmp
+  echo "ceTaskUrl=http://localhost:9000/api/ce/task?id=AXlCe3jz9LkwR9Gs0pBY" >> metadata_tmp
+
+  #mock curl
+  function curl() {
+     echo '{"task":{"analysisId":"AXlCe3jz9LkwR9Gs0pBY","status":"PENDING"}}'
+  }
+  export -f curl
+
+  run script/check-quality-gate.sh metadata_tmp 5
+
+  [ "$status" -eq 1 ]
+  [[ "${github_out_actual}" = "quality-gate-status=FAILED" ]]
+  [[ "$output" = *"Polling timeout reached for waiting for finishing of the Sonar scan! Aborting the check for SonarQube's Quality Gate."* ]]
 }
 
 @test "fail when Quality Gate status WARN" {
@@ -94,7 +140,7 @@ teardown() {
   }
   export -f curl
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
 
   read -r github_out_actual < ${GITHUB_OUTPUT}
 
@@ -121,7 +167,7 @@ teardown() {
   }
   export -f curl
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
 
   read -r github_out_actual < ${GITHUB_OUTPUT}
 
@@ -147,7 +193,7 @@ teardown() {
   }
   export -f curl
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
 
   read -r github_out_actual < ${GITHUB_OUTPUT}
 
@@ -187,7 +233,7 @@ teardown() {
   }
   export -f sleep
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
 
   read -r github_out_actual < ${GITHUB_OUTPUT}
 
@@ -220,7 +266,7 @@ teardown() {
   export GITHUB_OUTPUT="${github_output_dir}/github_output"
   touch "${GITHUB_OUTPUT}"
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
 
   read -r github_out_actual < "${GITHUB_OUTPUT}"
 
@@ -246,7 +292,7 @@ teardown() {
   }
   export -f curl
 
-  run script/check-quality-gate.sh metadata_tmp
+  run script/check-quality-gate.sh metadata_tmp 300
 
   [ "$status" -eq 0 ]
   [[ "$output" = *"::set-output name=quality-gate-status::PASSED"* ]]


### PR DESCRIPTION
The property timeout-minutes in a GitHub step is not supported in composed actions. So the workaround to stop the waiting for finishing the sonar scan is not working in such cases. To fix this issue, a polling timeout variable was introduced, which stops the waiting, if the timeout is reached.